### PR TITLE
skip no-commit-to-branch

### DIFF
--- a/.github/workflows/precommit.yml
+++ b/.github/workflows/precommit.yml
@@ -20,3 +20,5 @@ jobs:
     # https://github.com/pre-commit/action
     - name: run pre-commit
       uses: pre-commit/action@v3.0.0
+      env:
+        SKIP: no-commit-to-branch


### PR DESCRIPTION
Skip the `no-commit-to-branch` pre-commit check when running in github actions workflow. GitHub's branch protection is enough for this case.